### PR TITLE
Cursor set as pointer on active, switched back to default line height…

### DIFF
--- a/src/components/styles/NavItem.styled.ts
+++ b/src/components/styles/NavItem.styled.ts
@@ -7,9 +7,11 @@ export const NavDiv = styled.div<{ isActive?: boolean; fontType: FontType }>`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
   ${fontTypeCss}
   transition: font-size 0.3s;
   text-transform: capitalize;
+  line-height: 1;
   ${(props) => {
     if (props.isActive) {
       return `
@@ -24,7 +26,6 @@ export const NavDiv = styled.div<{ isActive?: boolean; fontType: FontType }>`
     }
     return `
       color: ${props.theme.palette.common.white};
-      cursor: pointer;
       &:hover {
         font-size: 25px;
       }


### PR DESCRIPTION
# Issues
It looks like when we moved over to styled typography, we imported the font style as h3 for `NavItem`, resulting in it having a 2.8 line height.
### Changes Made
- Added cursor pointer even when NavItem is active
- Reset line height of NavItem