### PR TITLE
Update NavBar visibility on scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import LoadingSpinner from './components/LoadingSpinner'
+import NavBar from './components/NavBar'
 import { Routes } from './routes/routes'
 import { GlobalStyle } from './styles/GlobalStyles'
 import Theme from './styles/Theme'
@@ -11,6 +12,7 @@ function App() {
       <Suspense fallback={<LoadingSpinner />}>
         <Theme>
           <GlobalStyle />
+          <NavBar />
           <Routes />
         </Theme>
       </Suspense>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -56,7 +56,7 @@ function NavBar() {
   const [isVisible, setVisible] = useState(true)
 
   const handleScroll = () => {
-    const currentScrollPos = window.pageYOffset
+    const currentScrollPos = window.scrollY
 
     setVisible(prevScrollPos > currentScrollPos)
     setPrevScrollPos(currentScrollPos)

--- a/src/components/styles/NavBar.styled.ts
+++ b/src/components/styles/NavBar.styled.ts
@@ -4,7 +4,6 @@ export const MainContainer = styled.div`
   width: 100vw;
   height: 5.5rem;
   display: flex;
-  ${(props) => `background-color: ${props.theme.palette.common.black};`}
 `
 export const BufferContainer = styled.div`
   width: 2vw;
@@ -14,11 +13,14 @@ export const NavBarStyles = styled.div<{ isVisible: boolean }>`
   display: flex;
   justify-content: space-evenly;
   margin-left: 8%;
-  margin-top: 0.5%;
-  top: ${(props) => (props.isVisible ? '0' : '-60px')};
+  padding-top: 0.5%;
+  position: fixed;
+  transform: ${(props) => (props.isVisible ? 'translateY(0)' : 'translateY(-100%)')};
+  transition: all 0.3s ease-in-out;
+  ${(props) => `background-color: ${props.theme.palette.common.black};`}
   @media (max-width: 900px) {
     margin-left: 4%;
-    margin-top: 3%;
+    padding-top: 3%;
     width: 80%;
   }
   @media (max-width: 650px) {

--- a/src/pages/About/styles/About.styled.ts
+++ b/src/pages/About/styles/About.styled.ts
@@ -2,10 +2,9 @@ import styled from 'styled-components'
 
 export const MainContainer = styled.div`
   margin: auto;
-  height: 100%;
-  width: 100%;
+  height: calc(100vh - 5.5rem);
+  width: 100vw;
   display: flex;
   flex-direction: column;
   padding: 50px 0px;
-  ${(props) => `background-color: ${props.theme.palette.common.black};`}
 `

--- a/src/pages/Events/styles/EventPage.styled.tsx
+++ b/src/pages/Events/styles/EventPage.styled.tsx
@@ -2,8 +2,7 @@ import styled from 'styled-components'
 
 export const MainContainer = styled.div`
   margin: auto;
-  min-height: 800px;
-  background-color: black;
+  height: calc(100vh - 5.5rem);
   display: flex;
   flex-direction: column;
   align-items: space-between;

--- a/src/pages/Home/styles/HomePage.styled.tsx
+++ b/src/pages/Home/styles/HomePage.styled.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
 export const MainContainer = styled.div`
-  height: calc(100vh - 4.8rem);
+  height: calc(100vh - 5.5rem);
   overflow: hidden;
 `

--- a/src/pages/Projects/styles/Projects.styled.ts
+++ b/src/pages/Projects/styles/Projects.styled.ts
@@ -3,7 +3,6 @@ import logoBackground from '../../../assets/logo-background.png'
 
 export const MainContainer = styled.div`
   height: calc(100vh - 5.5rem);
-  background-color: ${(props) => props.theme.palette.common.black};
   overflow-y: scroll;
 `
 

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Route, Routes as Switch } from 'react-router-dom'
 import { PATHS } from './PATHS'
-import NavBar from '../components/NavBar'
 
 const Home = React.lazy(() => import(/* webpackChunckName: "Home" */ '../pages/Home'))
 const About = React.lazy(() => import(/* webpackChunckName: "About" */ '../pages/About'))
@@ -12,16 +11,13 @@ const Projects = React.lazy(() => import(/* webpackChunckName: "Projects" */ '..
 
 export function Routes() {
   return (
-    <>
-      <NavBar />
-      <Switch>
-        <Route path="/" element={<Home />} />
-        <Route path={PATHS.ABOUT} element={<About />} />
-        <Route path={PATHS.ARTICLES} element={<Articles />} />
-        <Route path={PATHS.CONTACT} element={<Contact />} />
-        <Route path={PATHS.EVENTS} element={<Events />} />
-        <Route path={PATHS.PROJECTS} element={<Projects />} />
-      </Switch>
-    </>
+    <Switch>
+      <Route path="/" element={<Home />} />
+      <Route path={PATHS.ABOUT} element={<About />} />
+      <Route path={PATHS.ARTICLES} element={<Articles />} />
+      <Route path={PATHS.CONTACT} element={<Contact />} />
+      <Route path={PATHS.EVENTS} element={<Events />} />
+      <Route path={PATHS.PROJECTS} element={<Projects />} />
+    </Switch>
   )
 }

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -8,6 +8,7 @@ export const GlobalStyle = createGlobalStyle`
 
   body {
     margin: 0;
+    background: ${(props) => props.theme.palette.common.black};
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
       'Droid Sans', 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
A few changes were made:
- Fix NavBar to be invisible when scrolling down and visible when scrolling back up 
- Add theme.palette.black to global style so all the pages background will be black
  - Remove background from Main Container from all the pages file (doesn't make the whole page black previously)
- Adjust height of each page to accommodate with height of NavBar so NavBar & Page content form 100vh (prevent scroll from appearing unnecessarily)