### PR TITLE
Fix NavBar not covering the full width while scrolling issue

### DIFF
--- a/src/components/styles/NavBar.styled.ts
+++ b/src/components/styles/NavBar.styled.ts
@@ -6,26 +6,23 @@ export const MainContainer = styled.div`
   display: flex;
 `
 export const BufferContainer = styled.div`
-  width: 2vw;
+  width: 3vw;
 `
 export const NavBarStyles = styled.div<{ isVisible: boolean }>`
-  width: 60%;
   display: flex;
-  justify-content: space-evenly;
+  width: 100%;
+  justify-content: flex-start;
   margin-left: 8%;
   padding-top: 0.5%;
   position: fixed;
   transform: ${(props) => (props.isVisible ? 'translateY(0)' : 'translateY(-100%)')};
-  transition: all 0.3s ease-in-out;
+  transition: transform 0.3s ease-in-out;
   ${(props) => `background-color: ${props.theme.palette.common.black};`}
   @media (max-width: 900px) {
     margin-left: 4%;
-    padding-top: 3%;
-    width: 80%;
   }
   @media (max-width: 650px) {
-    margin-left: 0;
-    width: 95%;
+    margin-left: 4%;
   }
 `
 export const NavContainer = styled.div`


### PR DESCRIPTION
Originally width keep changing to account for diff screen size and to keep nav bar contents on the left hand side.
-> Change width to 100% to cover width of screen when scrolling
-> Use flex-start to move contents to the left of the nav bar