### PR TITLE
Fix truncated nav bar during scroll

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -25,8 +25,8 @@ function NavBar() {
   }, [prevScrollPos, isVisible, handleScroll])
 
   return (
-    <MainContainer>
-      <NavItemContainer isVisible={isVisible}>
+    <MainContainer isVisible={isVisible}>
+      <NavItemContainer>
         {navTitles.map((item) => (
           <NavItem
             text={item}

--- a/src/components/styles/NavBar.styled.ts
+++ b/src/components/styles/NavBar.styled.ts
@@ -1,20 +1,24 @@
 import styled from 'styled-components'
 
-export const MainContainer = styled.div`
-  width: 100%;
+export const MainContainer = styled.div<{ isVisible: boolean }>`
+  width: 100vw;
   height: 5rem;
-`
-
-export const NavItemContainer = styled.div<{ isVisible: boolean }>`
-  height: 5rem;
-  display: flex;
   position: fixed;
-  margin-left: 3rem;
-  transform: ${(props) => (props.isVisible ? 'translateY(0)' : 'translateY(-100%)')};
+  transform: ${(props) => (props.isVisible ? 'translateY(0%)' : 'translateY(-150%)')};
   transition: transform 0.3s ease-in-out;
   background-color: ${(props) => `${props.theme.palette.common.black}`};
+`
+
+export const NavItemContainer = styled.div`
+  height: 5rem;
+  display: flex;
+  margin-left: 3rem;
 
   div + div {
     margin-left: 2rem;
   }
+`
+
+export const NavBarSpace = styled.div`
+  margin-top: 5.5rem;
 `

--- a/src/pages/About/index.tsx
+++ b/src/pages/About/index.tsx
@@ -1,3 +1,4 @@
+import { NavBarSpace } from 'src/components/styles/NavBar.styled'
 import {
   missionDescription,
   visionDescription,
@@ -16,6 +17,7 @@ import UIUXLogo from '../../assets/UIUX-logo.png'
 export default function About() {
   return (
     <MainContainer>
+      <NavBarSpace />
       <PageSectionComponent title="Mission" description={missionDescription} hasImage={false} />
       <PageSectionComponent title="Vision" description={visionDescription} hasImage={false} />
       <PageSectionComponent

--- a/src/pages/About/styles/About.styled.ts
+++ b/src/pages/About/styles/About.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const MainContainer = styled.div`
   margin: auto;
-  height: calc(100vh - 5.5rem);
+  height: 100vh;
   display: flex;
   flex-direction: column;
 `

--- a/src/pages/Contact/index.tsx
+++ b/src/pages/Contact/index.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from 'styled-components'
+import { NavBarSpace } from 'src/components/styles/NavBar.styled'
 import ContactForm from '../../components/Contact'
 import {
   MainContainer,
@@ -20,6 +21,7 @@ export default function Contact() {
   const { body, h1, h3 } = { ...theme.typography.fontSize }
   return (
     <MainContainer>
+      <NavBarSpace />
       <ContactTitle fontType={h1}>Contact Us</ContactTitle>
       <StaticSection>
         <InformationSection>

--- a/src/pages/Events/index.tsx
+++ b/src/pages/Events/index.tsx
@@ -1,3 +1,4 @@
+import { NavBarSpace } from 'src/components/styles/NavBar.styled'
 import PageSectionComponent from '../../components/PageSection'
 import { MainContainer } from './styles/EventPage.styled'
 import { interHallHackathon } from '../../texts/descriptions/events'
@@ -5,6 +6,7 @@ import { interHallHackathon } from '../../texts/descriptions/events'
 export default function Events() {
   return (
     <MainContainer>
+      <NavBarSpace />
       <PageSectionComponent
         title={interHallHackathon.eventName}
         description={interHallHackathon.eventDescription}

--- a/src/pages/Events/styles/EventPage.styled.tsx
+++ b/src/pages/Events/styles/EventPage.styled.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components'
 
 export const MainContainer = styled.div`
-  margin: 30px 0;
-  height: calc(100vh - 5.5rem);
+  margin-bottom: 30px;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: space-between;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,9 +1,10 @@
 import RHDevLogo from '../../components/RHDevLogo'
-import { MainContainer } from './styles/HomePage.styled'
+import { MainContainer, Space } from './styles/HomePage.styled'
 
 export default function Home() {
   return (
     <MainContainer>
+      <Space />
       <RHDevLogo />
     </MainContainer>
   )

--- a/src/pages/Home/styles/HomePage.styled.tsx
+++ b/src/pages/Home/styles/HomePage.styled.tsx
@@ -1,6 +1,10 @@
 import styled from 'styled-components'
 
 export const MainContainer = styled.div`
-  height: calc(100vh - 5.5rem);
+  height: 100vh;
   overflow: hidden;
+`
+
+export const Space = styled.div`
+  margin-top: 3rem;
 `

--- a/src/pages/Projects/styles/Projects.styled.ts
+++ b/src/pages/Projects/styles/Projects.styled.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import logoBackground from '../../../assets/logo-background.png'
 
 export const MainContainer = styled.div`
-  height: calc(100vh - 5.5rem);
+  height: 100vh;
   display: grid;
   grid-template-rows: 1fr max-content;
   grid-template-columns: 1fr;


### PR DESCRIPTION
Bug fixed: During scroll, left part and right part of nav bar without text was exposed. 
Put reused code in NavBar file to be used in the other pages to prevent the content from being blocked by the NavBar when website at the top of the page.